### PR TITLE
Allow no logo version of price widget - uses noLogo query param

### DIFF
--- a/nz-test-harness.html
+++ b/nz-test-harness.html
@@ -13,7 +13,10 @@
       <div class="row">
         <div class="col-sm-12">
           <br>
+          <p>With Oxipay logo</p>
           <script id='oxipay-price-info' src="widgets/nz/price-info.js?productPrice=100"></script>
+          <p>Without Oxipay logo</p>
+          <script id='oxipay-price-info' src="widgets/nz/price-info.js?productPrice=500&noLogo"></script>
           <script id='oxipay-banner' src="widgets/nz/more-info-large.js"></script>
           <script id='oxipay-banner' src="widgets/nz/more-info-small.js"></script>
         </div>

--- a/src/nz/price-info.ts
+++ b/src/nz/price-info.ts
@@ -22,7 +22,8 @@ import { Config } from './config';
     }
 
 
-    var queryProductPrice = value.replace(/^[^\?]+\??/, '').substring(13);
+    var queryProductPrice = getParameterByName('productPrice',value);
+    var nologo = (getParameterByName('noLogo',value) !== null);
 
     productPrice = parseFloat(queryProductPrice);
 
@@ -38,9 +39,22 @@ import { Config } from './config';
             <p>or 4 payments of <b>$${roundedDownProductPrice.toFixed(2)}</b></p><p>Interest free with <span id="oxipay-img"></span></p>
         </a><br>`;
 
+    const templatenologo = `<a id="oxipay-tag-02" href="#${Config.priceInfoModalId}">
+            <p>or 4 payments of <b>$${roundedDownProductPrice.toFixed(2)}</b></p><p>Interest free - <strong>find out how</strong></p>
+        </a><br>`;
+
     const widget = new ModalInjector($);
-    widget.injectBanner(template, Config.priceInfoUrl);
+    widget.injectBanner((nologo) ? templatenologo : template, Config.priceInfoUrl);
 
 
 
 })(jq);
+
+function getParameterByName(name, url) {
+    name = name.replace(/[\[\]]/g, "\\$&");
+    var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+        results = regex.exec(url);
+    if (!results) return null;
+    if (!results[2]) return '';
+    return decodeURIComponent(results[2].replace(/\+/g, " "));
+}


### PR DESCRIPTION
Sure no problem - update done - cheers James

The test harness currently still seems to go through the widgets folder rather than dist - but I assume that is either intentional or will be changed at some point in the future